### PR TITLE
Support for esp-idf framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ __pycache__/
 # Intellij Idea
 .idea
 
+# Eclipse
+.project
+.cproject
+.pydevproject
+.settings/
+
 # Vim
 *.swp
 

--- a/esphome/components/wireguard/README.md
+++ b/esphome/components/wireguard/README.md
@@ -9,4 +9,12 @@ wireguard:
   private_key: private_key=
   peer_key: public_key=
   peer_endpoint: wg.server.example
+
+  # optional
+  peer_port: 12345
+  preshared_key: preshared_key=
+  netmask: 255.255.255.0
+
+  # optional (only for esp-idf framework)
+  keepalive: 25
 ```

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -30,7 +30,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_WG_PEER_KEY): cv.string,
         cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.port,
         cv.Optional(CONF_WG_PRESHARED_KEY): cv.string,
-        cv.Optional(CONF_WG_KEEPALIVE): cv.All(cv.positive_int, cv.only_with_esp_idf),
+        cv.Optional(CONF_WG_KEEPALIVE, default=0): cv.All(
+            cv.positive_int, cv.only_with_esp_idf
+        ),
     }
 ).extend(cv.polling_component_schema("10s"))
 
@@ -50,9 +52,7 @@ async def to_code(config):
     # ESP-IDF section
     if CORE.using_esp_idf:
         cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
-
-        if CONF_WG_KEEPALIVE in config:
-            cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
+        cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
 
         cg.add_build_flag("-DCONFIG_WIREGUARD_ESP_NETIF")
         cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_PEERS=1")

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -30,9 +30,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_WG_PEER_KEY): cv.string,
         cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.port,
         cv.Optional(CONF_WG_PRESHARED_KEY): cv.string,
-        cv.Optional(CONF_WG_KEEPALIVE, default=0): cv.All(
-            cv.positive_int, cv.only_with_esp_idf
-        ),
+        cv.Optional(CONF_WG_KEEPALIVE): cv.All(cv.positive_int, cv.only_with_esp_idf),
     }
 ).extend(cv.polling_component_schema("10s"))
 
@@ -52,7 +50,11 @@ async def to_code(config):
     # ESP-IDF section
     if CORE.using_esp_idf:
         cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
-        cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
+
+        if CONF_WG_KEEPALIVE in config:
+            cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
+        else:
+            cg.add(var.set_keepalive(0))
 
         cg.add_build_flag("-DCONFIG_WIREGUARD_ESP_NETIF")
         cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_PEERS=1")

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -56,11 +56,6 @@ async def to_code(config):
         else:
             cg.add(var.set_keepalive(0))
 
-        cg.add_build_flag("-DCONFIG_WIREGUARD_ESP_NETIF")
-        cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_PEERS=1")
-        cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_SRC_IPS=2")
-        cg.add_build_flag("-DCONFIG_MAX_INITIATIONS_PER_SECOND=2")
-        cg.add_build_flag("-DCONFIG_WIREGUARD_x25519_IMPLEMENTATION_DEFAULT")
         cg.add_library("https://github.com/droscy/esp_wireguard", None)
 
     # Arduino section

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -4,14 +4,14 @@ from esphome.const import CONF_ID, CONF_TIME_ID
 from esphome.core import CORE
 from esphome.components import time
 
-CONF_WG_ADDRESS = "address"
-CONF_WG_NETMASK = "netmask"
-CONF_WG_PRIVATE_KEY = "private_key"
-CONF_WG_PEER_ENDPOINT = "peer_endpoint"
-CONF_WG_PEER_PUBLIC_KEY = "peer_public_key"
-CONF_WG_PEER_PORT = "peer_port"
-CONF_WG_PRESHARED_KEY = "peer_preshared_key"
-CONF_WG_KEEPALIVE = "peer_persistent_keepalive"
+CONF_ADDRESS = "address"
+CONF_NETMASK = "netmask"
+CONF_PRIVATE_KEY = "private_key"
+CONF_PEER_ENDPOINT = "peer_endpoint"
+CONF_PEER_PUBLIC_KEY = "peer_public_key"
+CONF_PEER_PORT = "peer_port"
+CONF_PEER_PRESHARED_KEY = "peer_preshared_key"
+CONF_PERSISTENT_KEEPALIVE = "peer_persistent_keepalive"
 
 DEPENDENCIES = ["time"]
 CODEOWNERS = ["@lhoracek"]
@@ -23,14 +23,16 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Wireguard),
         cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
-        cv.Required(CONF_WG_ADDRESS): cv.string,
-        cv.Optional(CONF_WG_NETMASK, default="255.255.255.255"): cv.string,
-        cv.Required(CONF_WG_PRIVATE_KEY): cv.string,
-        cv.Required(CONF_WG_PEER_ENDPOINT): cv.string,
-        cv.Required(CONF_WG_PEER_PUBLIC_KEY): cv.string,
-        cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.port,
-        cv.Optional(CONF_WG_PRESHARED_KEY): cv.string,
-        cv.Optional(CONF_WG_KEEPALIVE): cv.All(cv.positive_int, cv.only_with_esp_idf),
+        cv.Required(CONF_ADDRESS): cv.string,
+        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.string,
+        cv.Required(CONF_PRIVATE_KEY): cv.string,
+        cv.Required(CONF_PEER_ENDPOINT): cv.string,
+        cv.Required(CONF_PEER_PUBLIC_KEY): cv.string,
+        cv.Optional(CONF_PEER_PORT, default=51820): cv.port,
+        cv.Optional(CONF_PEER_PRESHARED_KEY): cv.string,
+        cv.Optional(CONF_PERSISTENT_KEEPALIVE): cv.All(
+            cv.positive_int, cv.only_with_esp_idf
+        ),
     }
 ).extend(cv.polling_component_schema("10s"))
 
@@ -38,21 +40,21 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    cg.add(var.set_address(config[CONF_WG_ADDRESS]))
-    cg.add(var.set_netmask(config[CONF_WG_NETMASK]))
-    cg.add(var.set_private_key(config[CONF_WG_PRIVATE_KEY]))
-    cg.add(var.set_peer_endpoint(config[CONF_WG_PEER_ENDPOINT]))
-    cg.add(var.set_peer_public_key(config[CONF_WG_PEER_PUBLIC_KEY]))
-    cg.add(var.set_peer_port(config[CONF_WG_PEER_PORT]))
-    if CONF_WG_PRESHARED_KEY in config:
-        cg.add(var.set_preshared_key(config[CONF_WG_PRESHARED_KEY]))
+    cg.add(var.set_address(config[CONF_ADDRESS]))
+    cg.add(var.set_netmask(config[CONF_NETMASK]))
+    cg.add(var.set_private_key(config[CONF_PRIVATE_KEY]))
+    cg.add(var.set_peer_endpoint(config[CONF_PEER_ENDPOINT]))
+    cg.add(var.set_peer_public_key(config[CONF_PEER_PUBLIC_KEY]))
+    cg.add(var.set_peer_port(config[CONF_PEER_PORT]))
+    if CONF_PEER_PRESHARED_KEY in config:
+        cg.add(var.set_preshared_key(config[CONF_PEER_PRESHARED_KEY]))
 
     # ESP-IDF section
     if CORE.using_esp_idf:
         cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
 
-        if CONF_WG_KEEPALIVE in config:
-            cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
+        if CONF_PERSISTENT_KEEPALIVE in config:
+            cg.add(var.set_keepalive(config[CONF_PERSISTENT_KEEPALIVE]))
         else:
             cg.add(var.set_keepalive(0))
 

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 CONF_WG_ADDRESS = "address"
+CONF_WG_NETMASK = "netmask"
 CONF_WG_PRIVATE_KEY = "private_key"
 CONF_WG_PEER_ENDPOINT = "peer_endpoint"
 CONF_WG_PEER_KEY = "peer_key"
@@ -19,6 +20,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Wireguard),
         cv.Required(CONF_WG_ADDRESS): cv.string,
+        cv.Optional(CONF_WG_NETMASK, default="255.255.255.255"): cv.string,
         cv.Required(CONF_WG_PRIVATE_KEY): cv.string,
         cv.Required(CONF_WG_PEER_ENDPOINT): cv.string,
         cv.Required(CONF_WG_PEER_KEY): cv.string,
@@ -32,6 +34,7 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     cg.add(var.set_address(config[CONF_WG_ADDRESS]))
+    cg.add(var.set_netmask(config[CONF_WG_NETMASK]))
     cg.add(var.set_private_key(config[CONF_WG_PRIVATE_KEY]))
     cg.add(var.set_peer_endpoint(config[CONF_WG_PEER_ENDPOINT]))
     cg.add(var.set_peer_key(config[CONF_WG_PEER_KEY]))

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -1,6 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TIME_ID
+from esphome.core import CORE
+from esphome.components import time
 
 CONF_WG_ADDRESS = "address"
 CONF_WG_NETMASK = "netmask"
@@ -9,6 +11,7 @@ CONF_WG_PEER_ENDPOINT = "peer_endpoint"
 CONF_WG_PEER_KEY = "peer_key"
 CONF_WG_PEER_PORT = "peer_port"
 CONF_WG_PRESHARED_KEY = "preshared_key"
+CONF_WG_KEEPALIVE = "keepalive"
 
 DEPENDENCIES = ["time"]
 CODEOWNERS = ["@lhoracek"]
@@ -19,18 +22,20 @@ Wireguard = wireguard_ns.class_("Wireguard", cg.Component, cg.PollingComponent)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Wireguard),
+        cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         cv.Required(CONF_WG_ADDRESS): cv.string,
         cv.Optional(CONF_WG_NETMASK, default="255.255.255.255"): cv.string,
         cv.Required(CONF_WG_PRIVATE_KEY): cv.string,
         cv.Required(CONF_WG_PEER_ENDPOINT): cv.string,
         cv.Required(CONF_WG_PEER_KEY): cv.string,
+        cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.port,
         cv.Optional(CONF_WG_PRESHARED_KEY): cv.string,
-        cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.int_,
+        cv.Optional(CONF_WG_KEEPALIVE): cv.All(cv.positive_int, cv.only_with_esp_idf),
     }
 ).extend(cv.polling_component_schema("10s"))
 
 
-def to_code(config):
+async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     cg.add(var.set_address(config[CONF_WG_ADDRESS]))
@@ -42,6 +47,22 @@ def to_code(config):
     if CONF_WG_PRESHARED_KEY in config:
         cg.add(var.set_preshared_key(config[CONF_WG_PRESHARED_KEY]))
 
-    cg.add_library("https://github.com/kienvu58/WireGuard-ESP32-Arduino", "0.1.5")
+    # ESP-IDF section
+    if CORE.using_esp_idf:
+        cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
 
-    yield cg.register_component(var, config)
+        if CONF_WG_KEEPALIVE in config:
+            cg.add(var.set_keepalive(config[CONF_WG_KEEPALIVE]))
+
+        cg.add_build_flag("-DCONFIG_WIREGUARD_ESP_NETIF")
+        cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_PEERS=1")
+        cg.add_build_flag("-DCONFIG_WIREGUARD_MAX_SRC_IPS=2")
+        cg.add_build_flag("-DCONFIG_MAX_INITIATIONS_PER_SECOND=2")
+        cg.add_build_flag("-DCONFIG_WIREGUARD_x25519_IMPLEMENTATION_DEFAULT")
+        cg.add_library("https://github.com/droscy/esp_wireguard", None)
+
+    # Arduino section
+    else:
+        cg.add_library("https://github.com/kienvu58/WireGuard-ESP32-Arduino", "0.1.5")
+
+    await cg.register_component(var, config)

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -8,10 +8,10 @@ CONF_WG_ADDRESS = "address"
 CONF_WG_NETMASK = "netmask"
 CONF_WG_PRIVATE_KEY = "private_key"
 CONF_WG_PEER_ENDPOINT = "peer_endpoint"
-CONF_WG_PEER_KEY = "peer_key"
+CONF_WG_PEER_PUBLIC_KEY = "peer_public_key"
 CONF_WG_PEER_PORT = "peer_port"
-CONF_WG_PRESHARED_KEY = "preshared_key"
-CONF_WG_KEEPALIVE = "keepalive"
+CONF_WG_PRESHARED_KEY = "peer_preshared_key"
+CONF_WG_KEEPALIVE = "peer_persistent_keepalive"
 
 DEPENDENCIES = ["time"]
 CODEOWNERS = ["@lhoracek"]
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_WG_NETMASK, default="255.255.255.255"): cv.string,
         cv.Required(CONF_WG_PRIVATE_KEY): cv.string,
         cv.Required(CONF_WG_PEER_ENDPOINT): cv.string,
-        cv.Required(CONF_WG_PEER_KEY): cv.string,
+        cv.Required(CONF_WG_PEER_PUBLIC_KEY): cv.string,
         cv.Optional(CONF_WG_PEER_PORT, default=51820): cv.port,
         cv.Optional(CONF_WG_PRESHARED_KEY): cv.string,
         cv.Optional(CONF_WG_KEEPALIVE): cv.All(cv.positive_int, cv.only_with_esp_idf),
@@ -42,7 +42,7 @@ async def to_code(config):
     cg.add(var.set_netmask(config[CONF_WG_NETMASK]))
     cg.add(var.set_private_key(config[CONF_WG_PRIVATE_KEY]))
     cg.add(var.set_peer_endpoint(config[CONF_WG_PEER_ENDPOINT]))
-    cg.add(var.set_peer_key(config[CONF_WG_PEER_KEY]))
+    cg.add(var.set_peer_public_key(config[CONF_WG_PEER_PUBLIC_KEY]))
     cg.add(var.set_peer_port(config[CONF_WG_PEER_PORT]))
     if CONF_WG_PRESHARED_KEY in config:
         cg.add(var.set_preshared_key(config[CONF_WG_PRESHARED_KEY]))

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -47,6 +47,11 @@ void Wireguard::dump_config(){
     ESP_LOGCONFIG(TAG, "  preshared key[%d]: %s",this->preshared_key_.length(), this->preshared_key_.data());
 }
 
+void Wireguard::on_shutdown() {
+    ESP_LOGD(TAG, "disconnecting...");
+    wg.end();
+}
+
 void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
 void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
 void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -52,13 +52,13 @@ void Wireguard::on_shutdown() {
     wg.end();
 }
 
-void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
-void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
-void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
-void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
-void Wireguard::set_peer_public_key(std::string key) { this->peer_public_key_ = std::move(key); }
-void Wireguard::set_peer_port(uint16_t port) { this->peer_port_ = port; }
-void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std::move(key); }
+void Wireguard::set_address(const std::string address) { this->address_ = std::move(address); }
+void Wireguard::set_netmask(const std::string netmask) { this->netmask_ = std::move(netmask); }
+void Wireguard::set_private_key(const std::string key) { this->private_key_ = std::move(key); }
+void Wireguard::set_peer_endpoint(const std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
+void Wireguard::set_peer_public_key(const std::string key) { this->peer_public_key_ = std::move(key); }
+void Wireguard::set_peer_port(const uint16_t port) { this->peer_port_ = port; }
+void Wireguard::set_preshared_key(const std::string key) { this->preshared_key_ = std::move(key); }
 
 }  // namespace wireguard
 }  // namespace esphome

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -13,9 +13,13 @@ void Wireguard::setup() {
     ESP_LOGI(TAG, "wireguard setup start");
 
     IPAddress local_ip(inet_addr(this->address_.data()));           // VPN IP for this VPN client
+    IPAddress netmask(inet_addr(this->netmask_.data()));
+    IPAddress gateway(0,0,0,0);  // default gatewey in wireguard implementation
 
     wg.begin(
         local_ip,
+        netmask,
+        gateway,
         this->private_key_.data(),
         this->peer_endpoint_.data(),
         this->peer_key_.data(),
@@ -33,6 +37,7 @@ void Wireguard::update() {
 void Wireguard::dump_config(){
     ESP_LOGCONFIG(TAG, "Configuration");
     ESP_LOGCONFIG(TAG, "  address: %s",this->address_.data());
+    ESP_LOGCONFIG(TAG, "  netmask: %s",this->netmask_.data());
     ESP_LOGCONFIG(TAG, "  private key: %s",this->private_key_.data());
     ESP_LOGCONFIG(TAG, "  endpoint: %s",this->peer_endpoint_.data());
     ESP_LOGCONFIG(TAG, "  peer key: %s",this->peer_key_.data());
@@ -41,6 +46,7 @@ void Wireguard::dump_config(){
 }
 
 void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
+void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
 void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
 void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
 void Wireguard::set_peer_key(std::string key) { this->peer_key_ = std::move(key); }

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -1,3 +1,5 @@
+#ifndef USE_ESP_IDF
+
 #include "esphome/core/log.h"
 #include "wireguard.h"
 #include "WireGuard-ESP32.h"
@@ -55,3 +57,5 @@ void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std:
 
 }  // namespace wireguard
 }  // namespace esphome
+
+#endif

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -24,7 +24,7 @@ void Wireguard::setup() {
         gateway,
         this->private_key_.data(),
         this->peer_endpoint_.data(),
-        this->peer_key_.data(),
+        this->peer_public_key_.data(),
         this->peer_port_,
         this->preshared_key_.length() > 0 ? this->preshared_key_.data() : NULL
     );
@@ -41,10 +41,10 @@ void Wireguard::dump_config(){
     ESP_LOGCONFIG(TAG, "  address: %s",this->address_.data());
     ESP_LOGCONFIG(TAG, "  netmask: %s",this->netmask_.data());
     ESP_LOGCONFIG(TAG, "  private key: %s",this->private_key_.data());
-    ESP_LOGCONFIG(TAG, "  endpoint: %s",this->peer_endpoint_.data());
-    ESP_LOGCONFIG(TAG, "  peer key: %s",this->peer_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer endpoint: %s",this->peer_endpoint_.data());
     ESP_LOGCONFIG(TAG, "  peer port: %d",this->peer_port_);
-    ESP_LOGCONFIG(TAG, "  preshared key[%d]: %s",this->preshared_key_.length(), this->preshared_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer public key: %s",this->peer_public_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer preshared key[%d]: %s",this->preshared_key_.length(), this->preshared_key_.data());
 }
 
 void Wireguard::on_shutdown() {
@@ -56,7 +56,7 @@ void Wireguard::set_address(std::string address) { this->address_ = std::move(ad
 void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
 void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
 void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
-void Wireguard::set_peer_key(std::string key) { this->peer_key_ = std::move(key); }
+void Wireguard::set_peer_public_key(std::string key) { this->peer_public_key_ = std::move(key); }
 void Wireguard::set_peer_port(uint16_t port) { this->peer_port_ = port; }
 void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std::move(key); }
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -31,7 +31,7 @@ class Wireguard : public PollingComponent {
   void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
   bool is_peer_up() const { return wg_peer_up_; }
-  time_t get_last_peer_up_timestamp() const { return wg_last_peer_up_; }
+  time_t get_last_peer_up() const { return wg_last_peer_up_; }
 #endif
 
  private:

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -2,12 +2,16 @@
 
 #include "esphome/core/component.h"
 
+#ifdef USE_ESP_IDF
+#include "esphome/components/time/real_time_clock.h"
+#include "esp_wireguard.h"
+#endif
+
 namespace esphome {
 namespace wireguard {
 
 class Wireguard : public PollingComponent {
  public:
-   
   void setup() override;
   void update() override;
   void dump_config() override;
@@ -19,8 +23,13 @@ class Wireguard : public PollingComponent {
   void set_private_key(std::string private_key);
   void set_peer_endpoint(std::string endpoint);
   void set_peer_key(std::string peer_key);
-  void set_peer_port(uint16_t addresses);
-  void set_preshared_key(std::string peer_key);
+  void set_peer_port(uint16_t port);
+  void set_preshared_key(std::string key);
+
+#ifdef USE_ESP_IDF
+  void set_keepalive(uint16_t seconds);
+  void set_srctime(time::RealTimeClock* srctime);
+#endif
 
  private:
   std::string address_;
@@ -30,6 +39,23 @@ class Wireguard : public PollingComponent {
   std::string peer_key_;
   std::string preshared_key_;
   uint16_t peer_port_;
+
+#ifdef USE_ESP_IDF
+  uint16_t keepalive_;
+  time::RealTimeClock* srctime_;
+
+  wireguard_config_t wg_config = ESP_WIREGUARD_CONFIG_DEFAULT();
+  wireguard_ctx_t wg_ctx = ESP_WIREGUARD_CONTEXT_DEFAULT();
+
+  esp_err_t wg_initialized = ESP_FAIL;
+  esp_err_t wg_connected = ESP_FAIL;
+  esp_err_t wg_aborted = ESP_FAIL;
+  time_t wg_last_peer_up = 0;
+  bool wg_peer_up = false;
+  char wg_tmp_buffer[34];
+
+  void start_connection();
+#endif
 };
 
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -30,8 +30,8 @@ class Wireguard : public PollingComponent {
 #ifdef USE_ESP_IDF
   void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
-  bool is_peer_up() const { return wg_peer_up; }
-  time_t get_last_peer_up_timestamp() const { return wg_last_peer_up; }
+  bool is_peer_up() const { return wg_peer_up_; }
+  time_t get_last_peer_up_timestamp() const { return wg_last_peer_up_; }
 #endif
 
  private:
@@ -47,16 +47,15 @@ class Wireguard : public PollingComponent {
   uint16_t keepalive_;
   time::RealTimeClock* srctime_;
 
-  wireguard_config_t wg_config = ESP_WIREGUARD_CONFIG_DEFAULT();
-  wireguard_ctx_t wg_ctx = ESP_WIREGUARD_CONTEXT_DEFAULT();
+  wireguard_config_t wg_config_ = ESP_WIREGUARD_CONFIG_DEFAULT();
+  wireguard_ctx_t wg_ctx_ = ESP_WIREGUARD_CONTEXT_DEFAULT();
 
-  esp_err_t wg_initialized = ESP_FAIL;
-  esp_err_t wg_connected = ESP_FAIL;
-  esp_err_t wg_aborted = ESP_FAIL;
-  time_t wg_last_peer_up = 0;
-  bool wg_peer_up = false;
+  esp_err_t wg_initialized_ = ESP_FAIL;
+  esp_err_t wg_connected_ = ESP_FAIL;
+  time_t wg_last_peer_up_ = 0;
+  bool wg_peer_up_ = false;
 
-  void start_connection();
+  void start_connection_();
 #endif
 };
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -21,9 +21,9 @@ class Wireguard : public PollingComponent {
 
   void set_address(std::string address);
   void set_netmask(std::string netmask);
-  void set_private_key(std::string private_key);
+  void set_private_key(std::string key);
   void set_peer_endpoint(std::string endpoint);
-  void set_peer_key(std::string peer_key);
+  void set_peer_public_key(std::string key);
   void set_peer_port(uint16_t port);
   void set_preshared_key(std::string key);
 
@@ -39,7 +39,7 @@ class Wireguard : public PollingComponent {
   std::string netmask_;
   std::string private_key_;
   std::string peer_endpoint_;
-  std::string peer_key_;
+  std::string peer_public_key_;
   std::string preshared_key_;
   uint16_t peer_port_;
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -15,6 +15,7 @@ class Wireguard : public PollingComponent {
   void setup() override;
   void update() override;
   void dump_config() override;
+  void on_shutdown() override;
 
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -19,16 +19,16 @@ class Wireguard : public PollingComponent {
 
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 
-  void set_address(std::string address);
-  void set_netmask(std::string netmask);
-  void set_private_key(std::string key);
-  void set_peer_endpoint(std::string endpoint);
-  void set_peer_public_key(std::string key);
-  void set_peer_port(uint16_t port);
-  void set_preshared_key(std::string key);
+  void set_address(const std::string address);
+  void set_netmask(const std::string netmask);
+  void set_private_key(const std::string key);
+  void set_peer_endpoint(const std::string endpoint);
+  void set_peer_public_key(const std::string key);
+  void set_peer_port(const uint16_t port);
+  void set_preshared_key(const std::string key);
 
 #ifdef USE_ESP_IDF
-  void set_keepalive(uint16_t seconds);
+  void set_keepalive(const uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
   bool is_peer_up() const { return wg_peer_up_; }
   time_t get_last_peer_up() const { return wg_last_peer_up_; }

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -52,7 +52,6 @@ class Wireguard : public PollingComponent {
   esp_err_t wg_aborted = ESP_FAIL;
   time_t wg_last_peer_up = 0;
   bool wg_peer_up = false;
-  char wg_tmp_buffer[34];
 
   void start_connection();
 #endif

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -14,7 +14,8 @@ class Wireguard : public PollingComponent {
 
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 
-  void set_address(std::string address); 
+  void set_address(std::string address);
+  void set_netmask(std::string netmask);
   void set_private_key(std::string private_key);
   void set_peer_endpoint(std::string endpoint);
   void set_peer_key(std::string peer_key);
@@ -23,6 +24,7 @@ class Wireguard : public PollingComponent {
 
  private:
   std::string address_;
+  std::string netmask_;
   std::string private_key_;
   std::string peer_endpoint_;
   std::string peer_key_;
@@ -33,3 +35,5 @@ class Wireguard : public PollingComponent {
 
 }  // namespace wireguard
 }  // namespace esphome
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -30,7 +30,8 @@ class Wireguard : public PollingComponent {
 #ifdef USE_ESP_IDF
   void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
-  bool is_peer_up();
+  bool is_peer_up() const { return wg_peer_up; }
+  time_t get_last_peer_up_timestamp() const { return wg_last_peer_up; }
 #endif
 
  private:

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -29,6 +29,7 @@ class Wireguard : public PollingComponent {
 #ifdef USE_ESP_IDF
   void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
+  bool is_peer_up();
 #endif
 
  private:
@@ -56,7 +57,6 @@ class Wireguard : public PollingComponent {
   void start_connection();
 #endif
 };
-
 
 }  // namespace wireguard
 }  // namespace esphome

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -77,15 +77,15 @@ void Wireguard::on_shutdown() {
     }
 }
 
-void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
-void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
-void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
-void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
-void Wireguard::set_peer_public_key(std::string key) { this->peer_public_key_ = std::move(key); }
-void Wireguard::set_peer_port(uint16_t port) { this->peer_port_ = port; }
-void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std::move(key); }
+void Wireguard::set_address(const std::string address) { this->address_ = std::move(address); }
+void Wireguard::set_netmask(const std::string netmask) { this->netmask_ = std::move(netmask); }
+void Wireguard::set_private_key(const std::string key) { this->private_key_ = std::move(key); }
+void Wireguard::set_peer_endpoint(const std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
+void Wireguard::set_peer_public_key(const std::string key) { this->peer_public_key_ = std::move(key); }
+void Wireguard::set_peer_port(const uint16_t port) { this->peer_port_ = port; }
+void Wireguard::set_preshared_key(const std::string key) { this->preshared_key_ = std::move(key); }
 
-void Wireguard::set_keepalive(uint16_t seconds) { this->keepalive_ = seconds; }
+void Wireguard::set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
 void Wireguard::set_srctime(time::RealTimeClock* srctime) { this->srctime_ = srctime; }
 
 void Wireguard::start_connection_() {

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -48,7 +48,7 @@ void Wireguard::update() {
     }
 
     strftime(WG_TMP_BUFFER, sizeof(WG_TMP_BUFFER), "offline since %Y-%m-%d %H:%M:%S", localtime(&wg_last_peer_up));
-    ESP_LOGD(TAG, "peer: %s", (wg_peer_up ? "connected" : WG_TMP_BUFFER));
+    ESP_LOGD(TAG, "peer: %s", (wg_peer_up ? "online" : WG_TMP_BUFFER));
 
     if(wg_peer_up)
         wg_last_peer_up = srctime_->now().timestamp;
@@ -76,6 +76,8 @@ void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std:
 
 void Wireguard::set_keepalive(uint16_t seconds) { this->keepalive_ = seconds; }
 void Wireguard::set_srctime(time::RealTimeClock* srctime) { this->srctime_ = srctime; }
+
+bool Wireguard::is_peer_up() { return this->wg_peer_up; }
 
 void Wireguard::start_connection() {
     if(wg_initialized != ESP_OK) {

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -22,9 +22,11 @@ void Wireguard::setup() {
     wg_config.endpoint = &peer_endpoint_[0];
     wg_config.public_key = &peer_key_[0];
     wg_config.port = peer_port_;
-    wg_config.preshared_key = &preshared_key_[0];
     wg_config.allowed_ip_mask = &netmask_[0];
     wg_config.persistent_keepalive = keepalive_;
+
+    if(preshared_key_.length() > 0)
+        wg_config.preshared_key = &preshared_key_[0];
 
     wg_initialized = esp_wireguard_init(&wg_config, &wg_ctx);
     

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -1,0 +1,127 @@
+#ifdef USE_ESP_IDF
+
+#include <functional>
+#include <time.h>
+#include "esphome/core/log.h"
+#include "esp_err.h"
+#include "esp_wireguard.h"
+#include "wireguard.h"
+
+
+namespace esphome {
+namespace wireguard {
+
+static const char * const TAG = "wireguard";
+static const int WG_MAX_PEER_DOWN = 120; // seconds
+
+void Wireguard::setup() {
+    ESP_LOGD(TAG, "initializing...");
+
+    wg_config.allowed_ip = &address_[0];
+    wg_config.private_key = &private_key_[0];
+    wg_config.endpoint = &peer_endpoint_[0];
+    wg_config.public_key = &peer_key_[0];
+    wg_config.port = peer_port_;
+    wg_config.preshared_key = &preshared_key_[0];
+    wg_config.allowed_ip_mask = &netmask_[0];
+    wg_config.persistent_keepalive = keepalive_;
+
+    wg_initialized = esp_wireguard_init(&wg_config, &wg_ctx);
+    
+    if(wg_initialized == ESP_OK)
+        ESP_LOGI(TAG, "initialized");
+    else
+        ESP_LOGE(TAG, "cannot initialize, error code %d", wg_initialized);
+
+    srctime_->add_on_time_sync_callback(std::bind(&Wireguard::start_connection, this));
+}
+
+void Wireguard::update() {
+    ESP_LOGD(TAG, "initialized: %s (error %d)", (wg_initialized == ESP_OK ? "yes" : "no"), wg_initialized);
+    ESP_LOGD(TAG, "connection: %s (error %d)", (wg_connected == ESP_OK ? "active" : "inactive"), wg_connected);
+
+    if(wg_initialized == ESP_OK && wg_connected == ESP_OK)
+        wg_peer_up = (esp_wireguardif_peer_is_up(&wg_ctx) == ESP_OK);
+    else
+        wg_peer_up = false;
+
+    strftime(wg_tmp_buffer, sizeof(wg_tmp_buffer), "offline since %F %T", localtime(&wg_last_peer_up));
+    ESP_LOGD(TAG, "peer: %s", (wg_peer_up ? "connected" : wg_tmp_buffer));
+
+    if(wg_peer_up)
+        wg_last_peer_up = srctime_->now().timestamp;
+    else if(wg_initialized == ESP_OK)
+    {
+        if(wg_connected == ESP_OK
+              && (srctime_->now().timestamp - wg_last_peer_up) > WG_MAX_PEER_DOWN)
+        {
+            ESP_LOGW(TAG, "peer offline for more than %d seconds", WG_MAX_PEER_DOWN);
+            ESP_LOGD(TAG, "aborting connection...");
+            wg_aborted = esp_wireguard_disconnect(&wg_ctx);
+            if(wg_aborted == ESP_OK)
+            {
+                ESP_LOGI(TAG, "connection aborted");
+                wg_connected = ESP_FAIL;
+                start_connection();
+            }
+            else
+                ESP_LOGE(TAG, "cannot abort connection, error code %d", wg_aborted);
+        }
+        else if(wg_connected != ESP_OK)
+        {
+            start_connection();
+        }
+    }
+}
+
+void Wireguard::dump_config() {
+    ESP_LOGCONFIG(TAG, "Configuration");
+    ESP_LOGCONFIG(TAG, "  address: %s",this->address_.data());
+    ESP_LOGCONFIG(TAG, "  netmask: %s",this->netmask_.data());
+    ESP_LOGCONFIG(TAG, "  private key: %s",this->private_key_.data());  // TODO print?
+    ESP_LOGCONFIG(TAG, "  endpoint: %s",this->peer_endpoint_.data());
+    ESP_LOGCONFIG(TAG, "  peer key: %s",this->peer_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer port: %d",this->peer_port_);
+    ESP_LOGCONFIG(TAG, "  preshared key[%d]: %s",this->preshared_key_.length(), this->preshared_key_.data());  // TODO print?
+    ESP_LOGCONFIG(TAG, "  keepalive: %d",this->keepalive_);
+}
+
+void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
+void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
+void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
+void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
+void Wireguard::set_peer_key(std::string key) { this->peer_key_ = std::move(key); }
+void Wireguard::set_peer_port(uint16_t port) { this->peer_port_ = port; }
+void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std::move(key); }
+
+void Wireguard::set_keepalive(uint16_t seconds) { this->keepalive_ = seconds; }
+void Wireguard::set_srctime(time::RealTimeClock* srctime) { this->srctime_ = srctime; }
+
+void Wireguard::start_connection() {
+	ESP_LOGD(TAG, "time synchronized");
+
+    if(wg_initialized == ESP_OK) {
+        if(wg_connected != ESP_OK) {
+            ESP_LOGD(TAG, "connecting...");
+            wg_connected = esp_wireguard_connect(&wg_ctx);
+            if(wg_connected == ESP_OK) {
+                ESP_LOGI(TAG, "connection started");
+            } else {
+                ESP_LOGW(TAG, "cannot start connection, error code %d", wg_connected);
+            }
+        } else {
+            ESP_LOGD(TAG, "connection already started");
+        }
+    } else {
+        ESP_LOGE(TAG, "cannot start connection, initialization in error with code %d", wg_initialized);
+        wg_connected = ESP_FAIL;
+    }
+
+    wg_last_peer_up = srctime_->now().timestamp;
+}
+
+}  // namespace wireguard
+}  // namespace esphome
+
+#endif
+// vim: tabstop=4 shiftwidth=4 expandtab

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -68,6 +68,13 @@ void Wireguard::dump_config() {
     ESP_LOGCONFIG(TAG, "  keepalive: %d",this->keepalive_);
 }
 
+void Wireguard::on_shutdown() {
+    if(wg_initialized == ESP_OK && wg_connected == ESP_OK) {
+        ESP_LOGD(TAG, "disconnecting...");
+        esp_wireguard_disconnect(&wg_ctx);
+    }
+}
+
 void Wireguard::set_address(std::string address) { this->address_ = std::move(address); }
 void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
 void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -60,11 +60,11 @@ void Wireguard::dump_config() {
     ESP_LOGCONFIG(TAG, "Configuration");
     ESP_LOGCONFIG(TAG, "  address: %s",this->address_.data());
     ESP_LOGCONFIG(TAG, "  netmask: %s",this->netmask_.data());
-    ESP_LOGCONFIG(TAG, "  private key: %s",this->private_key_.data());  // TODO print?
+    ESP_LOGCONFIG(TAG, "  private key: %s...=",this->private_key_.substr(0,5).data());
     ESP_LOGCONFIG(TAG, "  endpoint: %s",this->peer_endpoint_.data());
     ESP_LOGCONFIG(TAG, "  peer key: %s",this->peer_key_.data());
     ESP_LOGCONFIG(TAG, "  peer port: %d",this->peer_port_);
-    ESP_LOGCONFIG(TAG, "  preshared key[%d]: %s",this->preshared_key_.length(), this->preshared_key_.data());  // TODO print?
+    ESP_LOGCONFIG(TAG, "  preshared key: %s...=",this->preshared_key_.substr(0,5).data());
     ESP_LOGCONFIG(TAG, "  keepalive: %d",this->keepalive_);
 }
 

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -18,7 +18,7 @@ void Wireguard::setup() {
     wg_config_.allowed_ip = &address_[0];
     wg_config_.private_key = &private_key_[0];
     wg_config_.endpoint = &peer_endpoint_[0];
-    wg_config_.public_key = &peer_key_[0];
+    wg_config_.public_key = &peer_public_key_[0];
     wg_config_.port = peer_port_;
     wg_config_.allowed_ip_mask = &netmask_[0];
     wg_config_.persistent_keepalive = keepalive_;
@@ -63,11 +63,11 @@ void Wireguard::dump_config() {
     ESP_LOGCONFIG(TAG, "  address: %s",this->address_.data());
     ESP_LOGCONFIG(TAG, "  netmask: %s",this->netmask_.data());
     ESP_LOGCONFIG(TAG, "  private key: %s...=",this->private_key_.substr(0,5).data());
-    ESP_LOGCONFIG(TAG, "  endpoint: %s",this->peer_endpoint_.data());
-    ESP_LOGCONFIG(TAG, "  peer key: %s",this->peer_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer endpoint: %s",this->peer_endpoint_.data());
     ESP_LOGCONFIG(TAG, "  peer port: %d",this->peer_port_);
-    ESP_LOGCONFIG(TAG, "  preshared key: %s...=",this->preshared_key_.substr(0,5).data());
-    ESP_LOGCONFIG(TAG, "  keepalive: %d",this->keepalive_);
+    ESP_LOGCONFIG(TAG, "  peer public key: %s",this->peer_public_key_.data());
+    ESP_LOGCONFIG(TAG, "  peer preshared key: %s...=",this->preshared_key_.substr(0,5).data());
+    ESP_LOGCONFIG(TAG, "  peer persistent keepalive: %d",this->keepalive_);
 }
 
 void Wireguard::on_shutdown() {
@@ -81,7 +81,7 @@ void Wireguard::set_address(std::string address) { this->address_ = std::move(ad
 void Wireguard::set_netmask(std::string netmask) { this->netmask_ = std::move(netmask); }
 void Wireguard::set_private_key(std::string key) { this->private_key_ = std::move(key); }
 void Wireguard::set_peer_endpoint(std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
-void Wireguard::set_peer_key(std::string key) { this->peer_key_ = std::move(key); }
+void Wireguard::set_peer_public_key(std::string key) { this->peer_public_key_ = std::move(key); }
 void Wireguard::set_peer_port(uint16_t port) { this->peer_port_ = port; }
 void Wireguard::set_preshared_key(std::string key) { this->preshared_key_ = std::move(key); }
 

--- a/esphome/components/wireguard/wireguard_esp_idf.cpp
+++ b/esphome/components/wireguard/wireguard_esp_idf.cpp
@@ -35,6 +35,7 @@ void Wireguard::setup() {
         srctime_->add_on_time_sync_callback(std::bind(&Wireguard::start_connection, this));
     } else {
         ESP_LOGE(TAG, "cannot initialize, error code %d", wg_initialized);
+        this->mark_failed();
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

I added support for esp-idf framework using my customized version of @trombik's wireguard implementation (see PR trombik/esp_wireguard#42, as soon as he merges my commits I'll update the link to the library used in `__init__.py` file).

I should have left almost anything untouched regarding the part for Arduino framwork except:

- added support for `netmask` parameter (commit 0c973a4658f8a90449b5c79c41e79ca57bc75643)
- called `wg.end()` inside `on_shutdown()` override (commit b00749d1db98e31fb12a133624d501d4a4c44684)
- changed yaml schema to be consistent with wireguard naming (commit c42805a744be399dd110219ec882b42b5b7cc8bf)

I didn't apply any clang-formatting, I tried to follow original file formatting.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** upstream PR esphome/esphome#4256

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
wireguard:
  address: x.y.z.w
  private_key: !secret wg_privkey
  peer_endpoint: wg.server.example
  peer_public_key: !secret wg_peer_pubkey

  # optional netmask (this is the default if omitted)
  netmask: 255.255.255.255

  # optional custom port (this is the wireguard default)
  peer_port: 51820

  # optional pre-shared key
  peer_preshared_key: !secret wg_peer_shrdkey

  # optional keepalive in seconds (disabled by default and
  # available only for esp-idf)
  peer_persistent_keepalive: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
