### PR TITLE
Allow Wireguard in Safe Mode, for remote OTA recovery

### DIFF
--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -1,7 +1,7 @@
 from esphome.components import time as time_
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.core import CORE
+from esphome.core import CORE, coroutine_with_priority
 from esphome.const import CONF_ID, CONF_SERVERS
 
 
@@ -22,6 +22,7 @@ CONFIG_SCHEMA = time_.TIME_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
+@coroutine_with_priority(54.0) # Allow in safe mode for Wireguard
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TIME_ID
 from esphome.components import time
+from esphome.core import coroutine_with_priority
 
 CONF_ADDRESS = "address"
 CONF_NETMASK = "netmask"
@@ -34,6 +35,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.polling_component_schema("10s"))
 
 
+@coroutine_with_priority(54.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.polling_component_schema("10s"))
 
 
-@coroutine_with_priority(54.0)
+@coroutine_with_priority(53.0) # Allow in safe mode
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 


### PR DESCRIPTION
In order to always allow OTA, even upon failure when ESPHome is in safe mode, it is convenient to have the VPN ready to be able to reflash/recover nodes remotely.

After exploring the different components in ESPHome, I found the way to run Wireguard in Safe Mode is to simply give it priority above 50 (it's the OTA component which decides `should_enter_safe_mode` https://github.com/esphome/esphome/blob/ceebe1462884fcec3c1453abd5c887c087377c02/esphome/components/ota/__init__.py#L79C1-L96).
That's the way wifi & captive portals work upon safe mode.

I've set the priority for Wireguard to 53, which is just after setting up MDNS and SNTP.

Gave it a quick test, it seems to work fine! :)
Now it is possible to recover nodes via OTA through VPN while in safe mode.
And I believe LAN OTA should still work, though I can't test it from here.

Snippet for testing:

```yaml
external_components:
  - source: github://carlosgs/esphome@patch-50
    components: [wireguard,sntp]

wireguard:
  address: $ipaddress
  private_key: $privkey
  peer_endpoint: $serverurl
  peer_public_key: $pubkey

button:
  - platform: safe_mode
    name: "Restart (Safe Mode)"
```
Back refs: https://github.com/esphome/esphome/pull/4256, https://github.com/esphome/feature-requests/issues/1444