### PR TITLE
Binary sensor to check if remote peer is up

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -271,6 +271,7 @@ esphome/components/web_server_base/* @OttoWinter
 esphome/components/whirlpool/* @glmnet
 esphome/components/whynter/* @aeonsablaze
 esphome/components/wireguard/* @lhoracek
+esphome/components/wireguard_status/* @droscy
 esphome/components/wl_134/* @hobbypunk90
 esphome/components/xiaomi_lywsd03mmc/* @ahpohl
 esphome/components/xiaomi_mhoc303/* @drug123

--- a/esphome/components/wireguard_status/binary_sensor.py
+++ b/esphome/components/wireguard_status/binary_sensor.py
@@ -1,0 +1,37 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor, wireguard
+from esphome.const import DEVICE_CLASS_CONNECTIVITY
+
+CONF_WIREGUARD_ID = "wireguard_id"
+
+DEPENDENCIES = ["wireguard"]
+CODEOWNERS = ["@droscy"]
+
+wireguard_ns = cg.esphome_ns.namespace("wireguard")
+sensors_ns = wireguard_ns.namespace("sensors")
+
+WireguardStatus = sensors_ns.class_(
+    "WireguardStatus",
+    binary_sensor.BinarySensor,
+    cg.PollingComponent,
+)
+
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(
+        WireguardStatus,
+        device_class=DEVICE_CLASS_CONNECTIVITY,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_WIREGUARD_ID): cv.use_id(wireguard.Wireguard),
+        }
+    )
+    .extend(cv.polling_component_schema("10s"))
+)
+
+
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    await cg.register_component(var, config)
+    cg.add(var.set_wireguard(await cg.get_variable(config[CONF_WIREGUARD_ID])))

--- a/esphome/components/wireguard_status/binary_sensor.py
+++ b/esphome/components/wireguard_status/binary_sensor.py
@@ -8,10 +8,9 @@ CONF_WIREGUARD_ID = "wireguard_id"
 DEPENDENCIES = ["wireguard"]
 CODEOWNERS = ["@droscy"]
 
-wireguard_ns = cg.esphome_ns.namespace("wireguard")
-sensors_ns = wireguard_ns.namespace("sensors")
+wireguard_status_ns = cg.esphome_ns.namespace("wireguard_status")
 
-WireguardStatus = sensors_ns.class_(
+WireguardStatus = wireguard_status_ns.class_(
     "WireguardStatus",
     binary_sensor.BinarySensor,
     cg.PollingComponent,

--- a/esphome/components/wireguard_status/wireguard_status.cpp
+++ b/esphome/components/wireguard_status/wireguard_status.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 
 namespace esphome {
-namespace wireguard {
-namespace sensors {
+namespace wireguard_status {
 
 static const char * const TAG = "wireguard_status.binary_sensor";
 
@@ -29,8 +28,7 @@ void WireguardStatus::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace sensors
-}  // namespace wireguard
+}  // namespace wireguard_status
 }  // namespace esphome
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/esphome/components/wireguard_status/wireguard_status.cpp
+++ b/esphome/components/wireguard_status/wireguard_status.cpp
@@ -1,0 +1,36 @@
+#include "wireguard_status.h"
+
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace wireguard {
+namespace sensors {
+
+static const char * const TAG = "wireguard_status.binary_sensor";
+
+void WireguardStatus::update() {
+  if(this->wireguard_ == nullptr) {
+    ESP_LOGW(TAG, "wireguard component not available");
+    return;
+  }
+
+  if(this->wireguard_->is_failed()) {
+    ESP_LOGE(TAG, "wireguard component is failed");
+    this->mark_failed();
+    return;
+  }
+
+  publish_state(this->wireguard_->is_peer_up());
+}
+
+void WireguardStatus::dump_config() {
+  LOG_BINARY_SENSOR("", "WireGuard Status", this);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+}  // namespace sensors
+}  // namespace wireguard
+}  // namespace esphome
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/esphome/components/wireguard_status/wireguard_status.h
+++ b/esphome/components/wireguard_status/wireguard_status.h
@@ -5,8 +5,7 @@
 #include "esphome/components/wireguard/wireguard.h"
 
 namespace esphome {
-namespace wireguard {
-namespace sensors {
+namespace wireguard_status {
 
 /// Binary sensor to report if the remote WireGuard peer is up.
 class WireguardStatus : public binary_sensor::BinarySensor,
@@ -16,14 +15,13 @@ class WireguardStatus : public binary_sensor::BinarySensor,
   void dump_config() override;
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
   void set_wireguard(wireguard::Wireguard* wireguard) { this->wireguard_ = wireguard; }
-  
+
  protected:
   /// Pointer to a configured wireguard::Wireguard component.
   wireguard::Wireguard* wireguard_ = nullptr;
 };
 
-}  // namespace sensors
-}  // namespace wireguard
+}  // namespace wireguard_status
 }  // namespace esphome
 
 // vim: tabstop=2 shiftwidth=2 expandtab

--- a/esphome/components/wireguard_status/wireguard_status.h
+++ b/esphome/components/wireguard_status/wireguard_status.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/wireguard/wireguard.h"
+
+namespace esphome {
+namespace wireguard {
+namespace sensors {
+
+/// Binary sensor to report if the remote WireGuard peer is up.
+class WireguardStatus : public binary_sensor::BinarySensor,
+                        public PollingComponent {
+ public:
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return esphome::setup_priority::LATE; }
+  void set_wireguard(wireguard::Wireguard* wireguard) { this->wireguard_ = wireguard; }
+  
+ protected:
+  /// Pointer to a configured wireguard::Wireguard component.
+  wireguard::Wireguard* wireguard_ = nullptr;
+};
+
+}  // namespace sensors
+}  // namespace wireguard
+}  // namespace esphome
+
+// vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
# What does this implement/fix?

A binary sensor to check if remote peer is up.

The sensor is a polling component because the underlying library does not notify the caller when the status changes. By default it checks the connection every 10 seconds, but it can be changed by the user.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
- upstream PR esphome/esphome#4256
- feature request esphome/feature-requests#1444

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# setup wireguard
wireguard:
    [...]

# define the sensor
binary_sensor:
  - platform: wireguard_status
    name: 'Wireguard Status'

    # optional (this is the default)
    #update_interval: 10s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
