### PR TITLE
New parameter peer_allowed_ips list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -271,6 +271,7 @@ esphome/components/web_server_base/* @OttoWinter
 esphome/components/whirlpool/* @glmnet
 esphome/components/whynter/* @aeonsablaze
 esphome/components/wireguard/* @lhoracek
+esphome/components/wireguard_handshake/* @droscy
 esphome/components/wl_134/* @hobbypunk90
 esphome/components/xiaomi_lywsd03mmc/* @ahpohl
 esphome/components/xiaomi_mhoc303/* @drug123

--- a/esphome/components/wireguard/README.md
+++ b/esphome/components/wireguard/README.md
@@ -1,20 +1,23 @@
-= Wireguard component
-Allows connecting esphome devices to VPN managed by https://www.wireguard.com/
+# Wireguard component
+Allows connecting esphome devices to VPN managed by [WireGuard](https://www.wireguard.com/)
 
 ```yaml
-# example configuration:
-
+# example configuration
 wireguard:
-  address: 10.0.0.1
+  address: x.y.z.w
   private_key: private_key=
-  peer_key: public_key=
   peer_endpoint: wg.server.example
+  peer_public_key: public_key=
 
-  # optional
-  peer_port: 12345
-  preshared_key: preshared_key=
-  netmask: 255.255.255.0
+  # optional netmask (this is the default if omitted)
+  netmask: 255.255.255.255
 
-  # optional (only for esp-idf framework)
-  keepalive: 25
+  # optional custom port (this is the wireguard default)
+  peer_port: 51820
+
+  # optional pre-shared key
+  peer_preshared_key: shared_key=
+
+  # optional keepalive in seconds (disabled by default)
+  peer_persistent_keepalive: 0
 ```

--- a/esphome/components/wireguard/README.md
+++ b/esphome/components/wireguard/README.md
@@ -27,6 +27,12 @@ wireguard:
 
   # optional keepalive in seconds (disabled by default)
   peer_persistent_keepalive: 25
+
+  # optional list of allowed ip/mask (default to any host)
+  peer_allowed_ips:
+    - x.y.z.0/24
+    - l.m.n.o/32  # the /32 can be omitted for single host
+    - [...]
 ```
 
 ## Sensors

--- a/esphome/components/wireguard/README.md
+++ b/esphome/components/wireguard/README.md
@@ -21,3 +21,31 @@ wireguard:
   # optional keepalive in seconds (disabled by default)
   peer_persistent_keepalive: 0
 ```
+
+If you give an `id` to the wireguard component you can manually create some sensors:
+
+```yaml
+wireguard:
+  id: vpn
+  [...]
+
+# a binary sensor to check if the remote peer is online
+binary_sensor:
+  - platform: template
+    name: 'WireGuard Status'
+    device_class: connectivity
+    lambda: |-
+      return id(vpn).is_peer_up();
+
+# a sensor to retrive the timestamp of the latest handshake
+sensor:
+  - platform: template
+    name: 'WireGuard Latest Handshake'
+    device_class: timestamp
+    lambda: |-
+      static time_t latest_handshake;
+      latest_handshake = id(vpn).get_latest_handshake();
+      return (latest_handshake > 0) ? latest_handshake : NAN;
+```
+
+Integrated sensors are under development...

--- a/esphome/components/wireguard/README.md
+++ b/esphome/components/wireguard/README.md
@@ -28,7 +28,7 @@ wireguard:
   # optional keepalive in seconds (disabled by default)
   peer_persistent_keepalive: 25
 
-  # optional list of allowed ip/mask (default to any host)
+  # optional list of allowed ip/mask (any host is allowed if omitted)
   peer_allowed_ips:
     - x.y.z.0/24
     - l.m.n.o/32  # the /32 can be omitted for single host

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -21,8 +21,8 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Wireguard),
         cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
-        cv.Required(CONF_ADDRESS): cv.string,
-        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.string,
+        cv.Required(CONF_ADDRESS): cv.ipv4,
+        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.ipv4,
         cv.Required(CONF_PRIVATE_KEY): cv.string,
         cv.Required(CONF_PEER_ENDPOINT): cv.string,
         cv.Required(CONF_PEER_PUBLIC_KEY): cv.string,
@@ -36,8 +36,8 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
-    cg.add(var.set_address(config[CONF_ADDRESS]))
-    cg.add(var.set_netmask(config[CONF_NETMASK]))
+    cg.add(var.set_address(str(config[CONF_ADDRESS])))
+    cg.add(var.set_netmask(str(config[CONF_NETMASK])))
     cg.add(var.set_private_key(config[CONF_PRIVATE_KEY]))
     cg.add(var.set_peer_endpoint(config[CONF_PEER_ENDPOINT]))
     cg.add(var.set_peer_public_key(config[CONF_PEER_PUBLIC_KEY]))

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -1,16 +1,15 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TIME_ID
+from esphome.const import CONF_ID, CONF_TIME_ID, CONF_ADDRESS
 from esphome.components import time
 
-CONF_ADDRESS = "address"
 CONF_NETMASK = "netmask"
 CONF_PRIVATE_KEY = "private_key"
 CONF_PEER_ENDPOINT = "peer_endpoint"
 CONF_PEER_PUBLIC_KEY = "peer_public_key"
 CONF_PEER_PORT = "peer_port"
 CONF_PEER_PRESHARED_KEY = "peer_preshared_key"
-CONF_PERSISTENT_KEEPALIVE = "peer_persistent_keepalive"
+CONF_PEER_PERSISTENT_KEEPALIVE = "peer_persistent_keepalive"
 
 DEPENDENCIES = ["time"]
 CODEOWNERS = ["@lhoracek"]
@@ -29,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_PEER_PUBLIC_KEY): cv.string,
         cv.Optional(CONF_PEER_PORT, default=51820): cv.port,
         cv.Optional(CONF_PEER_PRESHARED_KEY): cv.string,
-        cv.Optional(CONF_PERSISTENT_KEEPALIVE, default=0): cv.positive_int,
+        cv.Optional(CONF_PEER_PERSISTENT_KEEPALIVE, default=0): cv.positive_int,
     }
 ).extend(cv.polling_component_schema("10s"))
 
@@ -47,7 +46,7 @@ async def to_code(config):
     if CONF_PEER_PRESHARED_KEY in config:
         cg.add(var.set_preshared_key(config[CONF_PEER_PRESHARED_KEY]))
 
-    cg.add(var.set_keepalive(config[CONF_PERSISTENT_KEEPALIVE]))
+    cg.add(var.set_keepalive(config[CONF_PEER_PERSISTENT_KEEPALIVE]))
     cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
 
     cg.add_library("https://github.com/droscy/esp_wireguard", None)

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -1,6 +1,6 @@
+import ipaddress
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import ipaddress
 from esphome.const import CONF_ID, CONF_TIME_ID, CONF_ADDRESS
 from esphome.components import time
 
@@ -82,6 +82,6 @@ async def to_code(config):
     # the '+1' modifier is relative to the device's own address that will
     # be automatically added to the provided list.
     cg.add_build_flag(f"-DCONFIG_WIREGUARD_MAX_SRC_IPS={len(allowed_ips) + 1}")
-    cg.add_library("droscy/esp_wireguard", "0.1.0")
+    cg.add_library("droscy/esp_wireguard", "0.2.0")
 
     await cg.register_component(var, config)

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -49,6 +49,6 @@ async def to_code(config):
     cg.add(var.set_keepalive(config[CONF_PEER_PERSISTENT_KEEPALIVE]))
     cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
 
-    cg.add_library("https://github.com/droscy/esp_wireguard", None)
+    cg.add_library("droscy/esp_wireguard", "0.1.0")
 
     await cg.register_component(var, config)

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -75,13 +75,13 @@ void Wireguard::on_shutdown() {
     }
 }
 
-void Wireguard::set_address(const std::string address) { this->address_ = std::move(address); }
-void Wireguard::set_netmask(const std::string netmask) { this->netmask_ = std::move(netmask); }
-void Wireguard::set_private_key(const std::string key) { this->private_key_ = std::move(key); }
-void Wireguard::set_peer_endpoint(const std::string endpoint) { this->peer_endpoint_ = std::move(endpoint); }
-void Wireguard::set_peer_public_key(const std::string key) { this->peer_public_key_ = std::move(key); }
+void Wireguard::set_address(const std::string& address) { this->address_ = std::move(address); }
+void Wireguard::set_netmask(const std::string& netmask) { this->netmask_ = std::move(netmask); }
+void Wireguard::set_private_key(const std::string& key) { this->private_key_ = std::move(key); }
+void Wireguard::set_peer_endpoint(const std::string& endpoint) { this->peer_endpoint_ = std::move(endpoint); }
+void Wireguard::set_peer_public_key(const std::string& key) { this->peer_public_key_ = std::move(key); }
 void Wireguard::set_peer_port(const uint16_t port) { this->peer_port_ = port; }
-void Wireguard::set_preshared_key(const std::string key) { this->preshared_key_ = std::move(key); }
+void Wireguard::set_preshared_key(const std::string& key) { this->preshared_key_ = std::move(key); }
 
 void Wireguard::set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
 void Wireguard::set_srctime(time::RealTimeClock* srctime) { this->srctime_ = srctime; }
@@ -104,10 +104,11 @@ void Wireguard::start_connection_() {
 
     ESP_LOGD(TAG, "connecting...");
     wg_connected_ = esp_wireguard_connect(&wg_ctx_);
-    if(wg_connected_ == ESP_OK)
+    if(wg_connected_ == ESP_OK) {
         ESP_LOGI(TAG, "connection started");
-    else
+    } else {
         ESP_LOGW(TAG, "cannot start connection, error code %d", wg_connected_);
+}
 }
 
 }  // namespace wireguard

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -75,6 +75,12 @@ void Wireguard::dump_config() {
             (this->preshared_key_.length() > 0 ? this->preshared_key_.substr(0,5).c_str() : "NOT IN USE"),
             (this->preshared_key_.length() > 0 ? "[...]=" : ""));
     ESP_LOGCONFIG(TAG, "  peer persistent keepalive: %d", this->keepalive_);
+    ESP_LOGCONFIG(TAG, "  peer allowed ips:");
+    for(int i=0; i<this->allowed_ips_.size(); i++) {
+        ESP_LOGCONFIG(TAG, "    - %s/%s",
+                std::get<0>(this->allowed_ips_[i]).c_str(),
+                std::get<1>(this->allowed_ips_[i]).c_str());
+    }
 }
 
 void Wireguard::on_shutdown() {
@@ -120,6 +126,11 @@ void Wireguard::set_peer_public_key(const std::string& key) { this->peer_public_
 void Wireguard::set_peer_port(const uint16_t port) { this->peer_port_ = port; }
 void Wireguard::set_preshared_key(const std::string& key) { this->preshared_key_ = std::move(key); }
 
+void Wireguard::add_allowed_ip(const std::string& ip, const std::string& netmask) {
+    this->allowed_ips_.push_back(
+            std::tuple<std::string, std::string>(std::move(ip), std::move(netmask)));
+}
+
 void Wireguard::set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
 void Wireguard::set_srctime(time::RealTimeClock* srctime) { this->srctime_ = srctime; }
 
@@ -145,6 +156,25 @@ void Wireguard::start_connection_() {
         ESP_LOGI(TAG, "connection started");
     } else {
         ESP_LOGW(TAG, "cannot start connection, error code %d", this->wg_connected_);
+        return;
+    }
+
+    ESP_LOGD(TAG, "configuring WireGuard allowed ips list...");
+    bool allowed_ips_ok = true;
+    for(std::tuple<std::string, std::string> ip : this->allowed_ips_) {
+        allowed_ips_ok &= (
+                esp_wireguard_add_allowed_ip(
+                    &(this->wg_ctx_),
+                    std::get<0>(ip).c_str(),
+                    std::get<1>(ip).c_str()) == ESP_OK);
+    }
+
+    if(allowed_ips_ok) {
+        ESP_LOGD(TAG, "allowed ips list configured correctly for remote WireGuard peer");
+    } else {
+        ESP_LOGE(TAG, "cannot configure WireGuard allowed ips list, aborting...");
+        this->on_shutdown();
+        this->mark_failed();
     }
 }
 

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -13,16 +13,16 @@ static const char * const TAG = "wireguard";
 void Wireguard::setup() {
     ESP_LOGD(TAG, "initializing...");
 
-    this->wg_config_.allowed_ip = &address_[0];
-    this->wg_config_.private_key = &private_key_[0];
-    this->wg_config_.endpoint = &peer_endpoint_[0];
-    this->wg_config_.public_key = &peer_public_key_[0];
-    this->wg_config_.port = peer_port_;
-    this->wg_config_.allowed_ip_mask = &netmask_[0];
-    this->wg_config_.persistent_keepalive = keepalive_;
+    this->wg_config_.allowed_ip = this->address_.c_str();
+    this->wg_config_.private_key = this->private_key_.c_str();
+    this->wg_config_.endpoint = this->peer_endpoint_.c_str();
+    this->wg_config_.public_key = this->peer_public_key_.c_str();
+    this->wg_config_.port = this->peer_port_;
+    this->wg_config_.allowed_ip_mask = this->netmask_.c_str();
+    this->wg_config_.persistent_keepalive = this->keepalive_;
 
     if(preshared_key_.length() > 0)
-        this->wg_config_.preshared_key = &preshared_key_[0];
+        this->wg_config_.preshared_key = this->preshared_key_.c_str();
 
     wg_initialized_ = esp_wireguard_init(&(this->wg_config_), &(this->wg_ctx_));
 
@@ -58,13 +58,13 @@ void Wireguard::update() {
 
 void Wireguard::dump_config() {
     ESP_LOGCONFIG(TAG, "Configuration");
-    ESP_LOGCONFIG(TAG, "  address: %s", this->address_.data());
-    ESP_LOGCONFIG(TAG, "  netmask: %s", this->netmask_.data());
-    ESP_LOGCONFIG(TAG, "  private key: %s...=", this->private_key_.substr(0,5).data());
-    ESP_LOGCONFIG(TAG, "  peer endpoint: %s", this->peer_endpoint_.data());
+    ESP_LOGCONFIG(TAG, "  address: %s", this->address_.c_str());
+    ESP_LOGCONFIG(TAG, "  netmask: %s", this->netmask_.c_str());
+    ESP_LOGCONFIG(TAG, "  private key: %s...CUT...=", this->private_key_.substr(0,5).c_str());
+    ESP_LOGCONFIG(TAG, "  peer endpoint: %s", this->peer_endpoint_.c_str());
     ESP_LOGCONFIG(TAG, "  peer port: %d", this->peer_port_);
-    ESP_LOGCONFIG(TAG, "  peer public key: %s", this->peer_public_key_.data());
-    ESP_LOGCONFIG(TAG, "  peer preshared key: %s...=", this->preshared_key_.substr(0,5).data());
+    ESP_LOGCONFIG(TAG, "  peer public key: %s", this->peer_public_key_.c_str());
+    ESP_LOGCONFIG(TAG, "  peer preshared key: %s...CUT...=", this->preshared_key_.substr(0,5).c_str());
     ESP_LOGCONFIG(TAG, "  peer persistent keepalive: %d", this->keepalive_);
 }
 

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -6,14 +6,11 @@
 #include "esp_err.h"
 #include "esp_wireguard.h"
 
-// Default rekey timeout of wireguard specification, defined also
-// in file wireguard.h of esp_wireguard library.
-#define REKEY_AFTER_TIME (120)
-
 namespace esphome {
 namespace wireguard {
 
 static const char * const TAG = "wireguard";
+static const uint8_t REKEY_AFTER_TIME = 120;  // seconds, defined in wireguard specification
 
 void Wireguard::setup() {
     ESP_LOGD(TAG, "initializing...");

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -1,5 +1,6 @@
 #include "wireguard.h"
 
+#include <time.h>
 #include <functional>
 #include "esphome/core/log.h"
 #include "esp_err.h"
@@ -73,6 +74,14 @@ void Wireguard::on_shutdown() {
         ESP_LOGD(TAG, "disconnecting...");
         esp_wireguard_disconnect(&(this->wg_ctx_));
     }
+}
+
+time_t Wireguard::get_latest_handshake() const {
+    time_t result;
+    if(esp_wireguard_latest_handshake(&(this->wg_ctx_), &result) != ESP_OK) {
+        result = 0;
+    }
+    return result;
 }
 
 void Wireguard::set_address(const std::string& address) { this->address_ = std::move(address); }

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -170,7 +170,7 @@ void Wireguard::start_connection_() {
     }
 
     if(allowed_ips_ok) {
-        ESP_LOGD(TAG, "allowed ips list configured correctly for remote WireGuard peer");
+        ESP_LOGD(TAG, "allowed ips list configured correctly");
     } else {
         ESP_LOGE(TAG, "cannot configure WireGuard allowed ips list, aborting...");
         this->on_shutdown();

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <time.h>
+#include <ctime>
 #include "esphome/core/component.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esp_wireguard.h"
@@ -22,13 +22,13 @@ class Wireguard : public PollingComponent {
   void set_private_key(const std::string& key);
   void set_peer_endpoint(const std::string& endpoint);
   void set_peer_public_key(const std::string& key);
-  void set_peer_port(const uint16_t port);
+  void set_peer_port(uint16_t port);
   void set_preshared_key(const std::string& key);
 
-  void set_keepalive(const uint16_t seconds);
+  void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
 
-  bool is_peer_up() const { return wg_peer_up_; }
+  bool is_peer_up() const;
   time_t get_latest_handshake() const;
 
  protected:
@@ -48,7 +48,7 @@ class Wireguard : public PollingComponent {
 
   esp_err_t wg_initialized_ = ESP_FAIL;
   esp_err_t wg_connected_ = ESP_FAIL;
-  bool wg_peer_up_ = false;
+  bool wg_peer_up_logged_ = false;
 
   void start_connection_();
 };

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -26,10 +26,11 @@ class Wireguard : public PollingComponent {
 
   void set_keepalive(const uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
+
   bool is_peer_up() const { return wg_peer_up_; }
   time_t get_last_peer_up() const { return wg_last_peer_up_; }
 
- private:
+ protected:
   std::string address_;
   std::string netmask_;
   std::string private_key_;

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <ctime>
+#include <vector>
+#include <tuple>
 #include "esphome/core/component.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esp_wireguard.h"
@@ -25,6 +27,8 @@ class Wireguard : public PollingComponent {
   void set_peer_port(uint16_t port);
   void set_preshared_key(const std::string& key);
 
+  void add_allowed_ip(const std::string& ip, const std::string& netmask);
+
   void set_keepalive(uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);
 
@@ -38,9 +42,12 @@ class Wireguard : public PollingComponent {
   std::string peer_endpoint_;
   std::string peer_public_key_;
   std::string preshared_key_;
-  uint16_t peer_port_;
 
+  std::vector<std::tuple<std::string, std::string>> allowed_ips_;
+
+  uint16_t peer_port_;
   uint16_t keepalive_;
+
   time::RealTimeClock* srctime_;
 
   wireguard_config_t wg_config_ = ESP_WIREGUARD_CONFIG_DEFAULT();

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <time.h>
 #include "esphome/core/component.h"
 #include "esphome/components/time/real_time_clock.h"
 #include "esp_wireguard.h"
@@ -28,7 +29,7 @@ class Wireguard : public PollingComponent {
   void set_srctime(time::RealTimeClock* srctime);
 
   bool is_peer_up() const { return wg_peer_up_; }
-  time_t get_last_peer_up() const { return wg_last_peer_up_; }
+  time_t get_latest_handshake() const;
 
  protected:
   std::string address_;
@@ -47,7 +48,6 @@ class Wireguard : public PollingComponent {
 
   esp_err_t wg_initialized_ = ESP_FAIL;
   esp_err_t wg_connected_ = ESP_FAIL;
-  time_t wg_last_peer_up_ = 0;
   bool wg_peer_up_ = false;
 
   void start_connection_();

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -16,13 +16,13 @@ class Wireguard : public PollingComponent {
 
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }
 
-  void set_address(const std::string address);
-  void set_netmask(const std::string netmask);
-  void set_private_key(const std::string key);
-  void set_peer_endpoint(const std::string endpoint);
-  void set_peer_public_key(const std::string key);
+  void set_address(const std::string& address);
+  void set_netmask(const std::string& netmask);
+  void set_private_key(const std::string& key);
+  void set_peer_endpoint(const std::string& endpoint);
+  void set_peer_public_key(const std::string& key);
   void set_peer_port(const uint16_t port);
-  void set_preshared_key(const std::string key);
+  void set_preshared_key(const std::string& key);
 
   void set_keepalive(const uint16_t seconds);
   void set_srctime(time::RealTimeClock* srctime);

--- a/esphome/components/wireguard_handshake/sensor.py
+++ b/esphome/components/wireguard_handshake/sensor.py
@@ -1,0 +1,41 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, wireguard
+from esphome.const import (
+    DEVICE_CLASS_TIMESTAMP,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+CONF_WIREGUARD_ID = "wireguard_id"
+
+DEPENDENCIES = ["wireguard"]
+CODEOWNERS = ["@droscy"]
+
+wireguard_ns = cg.esphome_ns.namespace("wireguard")
+sensors_ns = wireguard_ns.namespace("sensors")
+
+WireguardHandshake = sensors_ns.class_(
+    "WireguardHandshake",
+    sensor.Sensor,
+    cg.PollingComponent,
+)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        WireguardHandshake,
+        device_class=DEVICE_CLASS_TIMESTAMP,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_WIREGUARD_ID): cv.use_id(wireguard.Wireguard),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+    cg.add(var.set_wireguard(await cg.get_variable(config[CONF_WIREGUARD_ID])))

--- a/esphome/components/wireguard_handshake/wireguard_handshake.cpp
+++ b/esphome/components/wireguard_handshake/wireguard_handshake.cpp
@@ -1,0 +1,44 @@
+#include "wireguard_handshake.h"
+
+#include <ctime>
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace wireguard {
+namespace sensors {
+
+static const char * const TAG = "wireguard_handshake.sensor";
+
+void WireguardHandshake::update() {
+  if(this->wireguard_ == nullptr) {
+    ESP_LOGW(TAG, "wireguard component not available");
+    this->has_state_ = false;
+    return;
+  }
+
+  if(this->wireguard_->is_failed()) {
+    ESP_LOGE(TAG, "wireguard component is failed");
+    this->mark_failed();
+    return;
+  }
+
+  time_t lhs = this->wireguard_->get_latest_handshake();
+
+  if(lhs > 0) {
+    publish_state((float)lhs);
+  } else {
+    this->has_state_ = false;
+  }
+}
+
+void WireguardHandshake::dump_config() {
+  LOG_SENSOR("", "WireGuard Latest Handshake", this);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+}  // namespace sensors
+}  // namespace wireguard
+}  // namespace esphome
+
+// vim: tabstop=2 shiftwidth=2 expandtab

--- a/esphome/components/wireguard_handshake/wireguard_handshake.h
+++ b/esphome/components/wireguard_handshake/wireguard_handshake.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/wireguard/wireguard.h"
+
+namespace esphome {
+namespace wireguard {
+namespace sensors {
+
+/// Track the timestamp of the latest completed handshake.
+class WireguardHandshake : public sensor::Sensor, public PollingComponent {
+ public:
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return esphome::setup_priority::LATE; }
+  void set_wireguard(wireguard::Wireguard* wireguard) { this->wireguard_ = wireguard; }
+  
+ protected:
+  /// Pointer to a configured wireguard::Wireguard component.
+  wireguard::Wireguard* wireguard_ = nullptr;
+};
+
+}  // namespace sensors
+}  // namespace wireguard
+}  // namespace esphome
+
+// vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
# What does this implement/fix?

Add support for allowed ips list through new parameter: `peer_allowed_ips`. If this parameter is omitted any host will be allowed (`0.0.0.0/0`) as it was before.

This branch is on top of PR #3 from commit https://github.com/lhoracek/esphome/pull/3/commits/b2e771d4046d198f47540f10c58c81651748777e.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
- #3 from commit https://github.com/lhoracek/esphome/pull/3/commits/b2e771d4046d198f47540f10c58c81651748777e (starting point)
- esphome/esphome#4256
- esphome/feature-requests#1444

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
wireguard:
  [...]

  # optional list of allowed ip/mask (any host is allowed if omitted)
  peer_allowed_ips:
    - x.y.z.0/24
    - l.m.n.o/32  # the /32 can be omitted for single host
    - [...]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
