### PR TITLE
Fix headers not found if sensors not loaded

### DIFF
--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -89,16 +89,20 @@ void Wireguard::update() {
     }
   }
 
+#ifdef USE_BINARY_SENSOR
   if (this->status_sensor_ != nullptr) {
     this->status_sensor_->publish_state(peer_up);
   }
+#endif
 
+#ifdef USE_SENSOR
   if (this->handshake_sensor_ != nullptr) {
     if (lhs > this->latest_saved_handshake_) {
       this->latest_saved_handshake_ = lhs;
       this->handshake_sensor_->publish_state((float) lhs);
     }
   }
+#endif
 }
 
 void Wireguard::dump_config() {
@@ -164,8 +168,14 @@ void Wireguard::add_allowed_ip(const std::string &ip, const std::string &netmask
 void Wireguard::set_keepalive(const uint16_t seconds) { this->keepalive_ = seconds; }
 void Wireguard::set_reboot_timeout(const uint32_t seconds) { this->reboot_timeout_ = seconds; }
 void Wireguard::set_srctime(time::RealTimeClock *srctime) { this->srctime_ = srctime; }
+
+#ifdef USE_BINARY_SENSOR
 void Wireguard::set_status_sensor(binary_sensor::BinarySensor *sensor) { this->status_sensor_ = sensor; }
+#endif
+
+#ifdef USE_SENSOR
 void Wireguard::set_handshake_sensor(sensor::Sensor *sensor) { this->handshake_sensor_ = sensor; }
+#endif
 
 void Wireguard::disable_auto_proceed() { this->proceed_allowed_ = false; }
 

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -8,8 +8,14 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/time/real_time_clock.h"
+
+#ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+#ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
+#endif
 
 #include <esp_wireguard.h>
 
@@ -39,8 +45,14 @@ class Wireguard : public PollingComponent {
   void set_keepalive(uint16_t seconds);
   void set_reboot_timeout(uint32_t seconds);
   void set_srctime(time::RealTimeClock *srctime);
+
+#ifdef USE_BINARY_SENSOR
   void set_status_sensor(binary_sensor::BinarySensor *sensor);
+#endif
+
+#ifdef USE_SENSOR
   void set_handshake_sensor(sensor::Sensor *sensor);
+#endif
 
   /// Block the setup step until peer is connected.
   void disable_auto_proceed();
@@ -63,8 +75,14 @@ class Wireguard : public PollingComponent {
   uint32_t reboot_timeout_;
 
   time::RealTimeClock *srctime_;
+
+#ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *status_sensor_ = nullptr;
+#endif
+
+#ifdef USE_SENSOR
   sensor::Sensor *handshake_sensor_ = nullptr;
+#endif
 
   /// Set to false to block the setup step until peer is connected.
   bool proceed_allowed_ = true;


### PR DESCRIPTION
# What does this implement/fix?

Fixes issue reported here https://github.com/esphome/esphome/pull/4256#issuecomment-1598964438

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes droscy/esphome#10

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# setup wireguard as usual
wireguard:
  [...]

# do not load sensor and/or binary_sensors
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
